### PR TITLE
Remove dependence on Floating for precision, fix rounding issues

### DIFF
--- a/src/Data/BigDecimal.hs
+++ b/src/Data/BigDecimal.hs
@@ -171,11 +171,8 @@ matchScales (a@(BigDecimal integerA scaleA), b@(BigDecimal integerB scaleB))
 -- | returns the number of digits of a BigDecimal
 precision :: BigDecimal -> Natural
 precision 0                  = 1
-precision (BigDecimal val _)
-  | val < (10 ^ 308) = 1 + floor (logBase 10 $ abs $ fromInteger val)
-  | otherwise = go 1 $ abs val
-    where
-        go ds n = if n >= 10 then go (ds + 1) (n `div` 10) else ds
+precision (BigDecimal val _) = go 1 $ abs val
+  where go ds n = if n >= 10 then go (ds + 1) (n `div` 10) else ds
 
 -- | removes trailing zeros from a BigDecimals intValue by decreasing the scale
 trim :: Natural -> BigDecimal -> BigDecimal

--- a/src/Data/BigDecimal.hs
+++ b/src/Data/BigDecimal.hs
@@ -171,7 +171,11 @@ matchScales (a@(BigDecimal integerA scaleA), b@(BigDecimal integerB scaleB))
 -- | returns the number of digits of a BigDecimal
 precision :: BigDecimal -> Natural
 precision 0                  = 1
-precision (BigDecimal val _) = 1 + floor (logBase 10 $ abs $ fromInteger val)
+precision (BigDecimal val _)
+  | val < (10 ^ 308) = 1 + floor (logBase 10 $ abs $ fromInteger val)
+  | otherwise = go 1 $ abs val
+    where
+        go ds n = if n >= 10 then go (ds + 1) (n `div` 10) else ds
 
 -- | removes trailing zeros from a BigDecimals intValue by decreasing the scale
 trim :: Natural -> BigDecimal -> BigDecimal


### PR DESCRIPTION
Two things here:

1. `logBase` dependence on `Floating a` means it won't work with numbers larger than Double maxvalue.
2. `logBase 10` is not great at handling values that are very close the next power of 10. e.g., `logBase 10 $ 10 ^ 20 - 1` returns 20 instead of 19.999999999.

As a result, I have to use the naive division by 10 for the purpose of avoiding the above pitfalls. It is not too much slower, still computes for huge numbers in << 1 second.